### PR TITLE
Change model_architecture param in README.md from resnet18 to resnet34

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This code is used to train a model to classify grayscale images from the Fashion
 The best model that I have trained so far had the following parameters:  
 `"batch_size": 128`  
 `"epochs": 10`  
-`"model_architecture": "resnet18"`  
+`"model_architecture": "resnet34"`  
 `"compute_type": "gpu"`  
 
 The printout is as follows:  


### PR DESCRIPTION
Parameter for the model architecture for best model was written incorrectly in the README.md as "resnet18", when it was in fact "resnet34". This has now been updated to be correct. 